### PR TITLE
Publish docker image to docker hub

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -50,10 +50,16 @@ case $1 in
   #
   # $ ./dist.sh build-docker {version}
   build-docker)
-    docker build --no-cache --target build -t crystallang/crystal:$2-build -f docker/crystal/Dockerfile .
-    docker build --target runtime -t crystallang/crystal:$2 -f docker/crystal/Dockerfile .
+    BUILD_ARGS_64='-f docker/crystal/Dockerfile --build-arg base_docker_image=ubuntu:xenial'
+    docker build --no-cache --target build -t crystallang/crystal:$2-build $BUILD_ARGS_64 .
+    docker build --target runtime -t crystallang/crystal:$2 $BUILD_ARGS_64 .
+
+    BUILD_ARGS_32='-f docker/crystal/Dockerfile --build-arg base_docker_image=i386/ubuntu:xenial --build-arg library_path=/opt/crystal/embedded/lib/'
+    docker build --no-cache --target build -t crystallang/crystal:$2-i386-build $BUILD_ARGS_32 .
+    docker build --target runtime -t crystallang/crystal:$2-i386 $BUILD_ARGS_32 .
 
     assert_installed_crystal_in_docker "$2-build" $2
+    assert_installed_crystal_in_docker "$2-i386-build" $2
     ;;
 
   # Push local built crystallang/crystal:{version} and crystallang/crystal:{version}-build
@@ -62,8 +68,11 @@ case $1 in
   # $ ./dist.sh push-docker {version}
   push-docker)
     assert_installed_crystal_in_docker "$2-build" $2
+    assert_installed_crystal_in_docker "$2-i386-build" $2
 
     docker push crystallang/crystal:$2
     docker push crystallang/crystal:$2-build
+    docker push crystallang/crystal:$2-i386
+    docker push crystallang/crystal:$2-i386-build
     ;;
 esac

--- a/docker/crystal/Dockerfile
+++ b/docker/crystal/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:xenial as runtime
+ARG base_docker_image
+FROM ${base_docker_image} as runtime
 
 RUN \
   apt-get update && \
@@ -6,7 +7,7 @@ RUN \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 09617FD37CC06B54 && \
   echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
   apt-get update && \
-  apt-get install -y crystal gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make && \
+  apt-get install -y tzdata crystal gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["/bin/bash"]
@@ -18,6 +19,7 @@ RUN \
   apt-get install -y build-essential llvm-4.0 libedit-dev libreadline-dev gdb && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV LIBRARY_PATH=/usr/lib/crystal/lib/
+ARG library_path=/usr/lib/crystal/lib/
+ENV LIBRARY_PATH=${library_path}
 
 CMD ["/bin/bash"]

--- a/docker/crystal/Dockerfile
+++ b/docker/crystal/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:xenial as runtime
+
+RUN \
+  apt-get update && \
+  apt-get install -y apt-transport-https && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 09617FD37CC06B54 && \
+  echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
+  apt-get update && \
+  apt-get install -y crystal gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+CMD ["/bin/bash"]
+
+FROM runtime as build
+
+RUN \
+  apt-get update && \
+  apt-get install -y build-essential llvm-4.0 libedit-dev libreadline-dev gdb && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV LIBRARY_PATH=/usr/lib/crystal/lib/
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
The following commands will build docker images based on ubuntu xenial using the crystal .deb file published in the apt-repository.

```
$ ./dist.sh build-docker {version}
$ ./dist.sh push-docker {version}
```

Upon building and pushing it is verified that `crystal --version` matches the `{version}` argument.

The following images are generated / pushed

* `crystallang/crystal:{version}`
* `crystallang/crystal:{version}-build`
* `crystallang/crystal:{version}-i386`
* `crystallang/crystal:{version}-i386-build`

`*-build` adds llvm4, gdb and sets the default `LIBRARY_PATH` in order to be able to build a crystal compiler without installing boehm-gc. 64 and 32 bits images would be used eventually in ci.