### PR TITLE
Replace key from keys.gnupg.net with keybase.io

### DIFF
--- a/dist/apt/setup.sh
+++ b/dist/apt/setup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54
+curl -L https://keybase.io/crystal/pgp_keys.asc | sudo apt-key add -
 echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list
 apt-get update


### PR DESCRIPTION
keys.gnupg.net has been known for being unreliable for quite some time. The manual installation instructions (now https://crystal-lang.org/install/on_ubuntu/ etc.) have already been using keybase.io since crystal-lang/crystal-book#262

Closes crystal-lang/crystal#4417

/cc https://forum.crystal-lang.org/t/installation-on-ubuntu-fail/1336