### PR TITLE
Add update-docs-versions task

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -102,7 +102,7 @@ case $1 in
   # $ ./dist.sh update-docs-versions {path-to-crystal-repo-working-dir}
   update-docs-versions)
     mkdir -p dist/api
-    sh -c "cd $1; scripts/docs-versions.cr" > dist/api/versions.json
+    sh -c "cd $1; scripts/docs-versions.sh" > dist/api/versions.json
     s3cmd -v sync dist/api/versions.json s3://crystal-api/api/versions.json
     ;;
 

--- a/dist.sh
+++ b/dist.sh
@@ -95,6 +95,23 @@ case $1 in
     tar xfz $3 -C dist/api/$2 --strip-component=2
     s3cmd -v sync dist/api/$2/ s3://crystal-api/api/$2/
     ;;
+    
+  # Update config file listing all Crystal versions available on API docs.
+  # File is available at https://crystal-lang.org/api/versions.js
+  #
+  # $ ./dist.sh update-docs-versions {version} {next-version}
+  update-docs-versions)
+    s3cmd -v sync s3://crystal-api/api/versions.js dist/api/versions.js
+    
+    # Update master name to next development version
+    sed -i dist/api/versions.js -e "2 s/name: \"$2-dev\"/name: \"$3-dev\"/"
+    # Remove latest label from previously labelled version
+    sed -i dist/api/versions.js -e '3 s/, latest: true//'
+    # Add new version at top but after master
+    sed -i dist/api/versions.js -e "2 a\  {name: "$2", url: \"/api/$2/\", latest: true}"
+    
+    s3cmd -v sync dist/api/versions.js s3://crystal-api/api/versions.js
+    ;;
 
   # Make {version} the default docs version so the following redirects occurs
   # /api/latest/Array.html -> /api/{version}/Array.html

--- a/dist.sh
+++ b/dist.sh
@@ -97,20 +97,13 @@ case $1 in
     ;;
     
   # Update config file listing all Crystal versions available on API docs.
-  # File is available at https://crystal-lang.org/api/versions.js
+  # File is available at https://crystal-lang.org/api/versions.json
   #
-  # $ ./dist.sh update-docs-versions {version} {next-version}
+  # $ ./dist.sh update-docs-versions {path-to-crystal-repo-working-dir}
   update-docs-versions)
-    s3cmd -v sync s3://crystal-api/api/versions.js dist/api/versions.js
-    
-    # Update master name to next development version
-    sed -i dist/api/versions.js -e "2 s/name: \"$2-dev\"/name: \"$3-dev\"/"
-    # Remove latest label from previously labelled version
-    sed -i dist/api/versions.js -e '3 s/, latest: true//'
-    # Add new version at top but after master
-    sed -i dist/api/versions.js -e "2 a\  {name: \"$2\", url: \"/api/$2/\", latest: true}"
-    
-    s3cmd -v sync dist/api/versions.js s3://crystal-api/api/versions.js
+    mkdir -p dist/api
+    sh -c "cd $1; scripts/docs-versions.js" > dist/api/versions.json
+    s3cmd -v sync dist/api/versions.json s3://crystal-api/api/versions.json
     ;;
 
   # Make {version} the default docs version so the following redirects occurs

--- a/dist.sh
+++ b/dist.sh
@@ -108,7 +108,7 @@ case $1 in
     # Remove latest label from previously labelled version
     sed -i dist/api/versions.js -e '3 s/, latest: true//'
     # Add new version at top but after master
-    sed -i dist/api/versions.js -e "2 a\  {name: "$2", url: \"/api/$2/\", latest: true}"
+    sed -i dist/api/versions.js -e "2 a\  {name: \"$2\", url: \"/api/$2/\", latest: true}"
     
     s3cmd -v sync dist/api/versions.js s3://crystal-api/api/versions.js
     ;;

--- a/dist.sh
+++ b/dist.sh
@@ -102,7 +102,7 @@ case $1 in
   # $ ./dist.sh update-docs-versions {path-to-crystal-repo-working-dir}
   update-docs-versions)
     mkdir -p dist/api
-    sh -c "cd $1; scripts/docs-versions.js" > dist/api/versions.json
+    sh -c "cd $1; scripts/docs-versions.cr" > dist/api/versions.json
     s3cmd -v sync dist/api/versions.json s3://crystal-api/api/versions.json
     ;;
 


### PR DESCRIPTION
Adds a new task to update the JavaScript config file required for the version select as proposed in https://github.com/crystal-lang/crystal/pull/9074 
This depends on the resolution of that PR but I wanted to demonstrate that integration with the Crystal API docs dist process should be really easy.

The current content of `/api/versions.js` would be:
```js
var projectVersions = [
  {name: "0.35.0-dev", url: "/api/master/", released: false},
  {name: "0.34.0", url: "/api/0.34.0/", latest: true},
  {name: "0.33.0", url: "/api/0.33.0/"},
  {name: "0.32.1", url: "/api/0.32.1/"},
  {name: "0.32.0", url: "/api/0.32.0/"},
  {name: "0.31.1", url: "/api/0.31.1/"},
  {name: "0.31.0", url: "/api/0.31.0/"},
  {name: "0.30.1", url: "/api/0.30.1/"},
  {name: "0.30.0", url: "/api/0.30.0/"},
  {name: "0.29.0", url: "/api/0.29.0/"},
  {name: "0.28.0", url: "/api/0.28.0/"},
  {name: "0.27.2", url: "/api/0.27.2/"},
  {name: "0.27.1", url: "/api/0.27.1/"},
  {name: "0.27.0", url: "/api/0.27.0/"},
  {name: "0.26.1", url: "/api/0.26.1/"},
  {name: "0.26.0", url: "/api/0.26.0/"},
  {name: "0.25.1", url: "/api/0.25.1/"},
  {name: "0.25.0", url: "/api/0.25.0/"},
  {name: "0.24.2", url: "/api/0.24.2/"},
  {name: "0.24.1", url: "/api/0.24.1/"},
  {name: "0.24.0", url: "/api/0.24.0/"},
  {name: "0.23.1", url: "/api/0.23.1/"},
  {name: "0.23.0", url: "/api/0.23.0/"},
  {name: "0.22.0", url: "/api/0.22.0/"},
  {name: "0.21.1", url: "/api/0.21.1/"},
  {name: "0.21.0", url: "/api/0.21.0/"},
  {name: "0.20.5", url: "/api/0.20.5/"},
  {name: "0.20.4", url: "/api/0.20.4/"},
  {name: "0.20.3", url: "/api/0.20.3/"},
  {name: "0.20.2", url: "/api/0.20.2/"},
  {name: "0.20.1", url: "/api/0.20.1/"},
  {name: "0.20.0", url: "/api/0.20.0/"}
];
```

I can't test dist, so it's not tested. The sed scripts work in isolation, though.