### PR TITLE
Update docker images to Crystal 1.1.0

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 function debian() {
@@ -56,15 +56,15 @@ case $1 in
     ;;
 
   # Build crystallang/crystal:{version} and crystallang/crystal:{version}-build
-  # docker images. It will install the published binaries at dist.crystal-lang.org/apt
+  # docker images. They contain the published binary packages from OBS.
   #
   # $ ./dist.sh build-docker {version}
   build-docker)
-    BUILD_ARGS_64='-f docker/crystal/Dockerfile --build-arg base_docker_image=ubuntu:bionic'
+    BUILD_ARGS_64='-f docker/crystal/Dockerfile --build-arg base_docker_image=ubuntu:20.04 --build-arg obs_repository=xUbuntu_20.04'
     docker build --no-cache --pull --target build -t crystallang/crystal:$2-build $BUILD_ARGS_64 .
     docker build --target runtime -t crystallang/crystal:$2 $BUILD_ARGS_64 .
 
-    BUILD_ARGS_32='-f docker/crystal/Dockerfile --build-arg base_docker_image=i386/ubuntu:bionic'
+    BUILD_ARGS_32='-f docker/crystal/Dockerfile --build-arg base_docker_image=i386/ubuntu:bionic --build-arg obs_repository=xUbuntu_18.04'
     docker build --no-cache --pull --target build -t crystallang/crystal:$2-i386-build $BUILD_ARGS_32 .
     docker build --target runtime -t crystallang/crystal:$2-i386 $BUILD_ARGS_32 .
 

--- a/docker/crystal/Dockerfile
+++ b/docker/crystal/Dockerfile
@@ -1,11 +1,12 @@
 ARG base_docker_image
+ARG obs_repository
 FROM ${base_docker_image} as runtime
 
 RUN \
   apt-get update && \
-  apt-get install -y apt-transport-https gnupg2 ca-certificates && \
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61 && \
-  echo "deb https://dl.bintray.com/crystal/deb all stable" | tee /etc/apt/sources.list.d/crystal.list && \
+  apt-get install -y wget gnupg2 && \
+  wget -qO- https://download.opensuse.org/repositories/devel:languages:crystal/xUbuntu_20.04/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/devel_languages_crystal.gpg && \
+  echo "deb http://download.opensuse.org/repositories/devel:languages:crystal/${obs_repository}/ /" > /etc/apt/sources.list.d/devel:languages:crystal.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y tzdata crystal gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make && \
@@ -17,9 +18,9 @@ FROM runtime as build
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm-8 lld-8 libedit-dev gdb && \
+  apt-get install -y build-essential llvm-10 lld-10 libedit-dev gdb && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN ln -sf /usr/bin/ld.lld-8 /usr/bin/ld.lld
+RUN ln -sf /usr/bin/ld.lld-10 /usr/bin/ld.lld
 
 CMD ["/bin/sh"]

--- a/docker/crystal/Dockerfile
+++ b/docker/crystal/Dockerfile
@@ -1,11 +1,11 @@
 ARG base_docker_image
-ARG obs_repository
 FROM ${base_docker_image} as runtime
 
+ARG obs_repository
 RUN \
   apt-get update && \
   apt-get install -y wget gnupg2 && \
-  wget -qO- https://download.opensuse.org/repositories/devel:languages:crystal/xUbuntu_20.04/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/devel_languages_crystal.gpg && \
+  wget -qO- https://download.opensuse.org/repositories/devel:languages:crystal/${obs_repository}/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/devel_languages_crystal.gpg && \
   echo "deb http://download.opensuse.org/repositories/devel:languages:crystal/${obs_repository}/ /" > /etc/apt/sources.list.d/devel:languages:crystal.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Also updates base image to Ubuntu 20.04 and LLVM 10

Resolves #12 

When testing the docker images, the binary in the 32-bit image causes a segmentation fault at startup (execve errors with EPERM). This seems to be caused by https://github.com/crystal-lang/crystal/issues/10948