### PR TITLE
Update readme when pushing docker images

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -84,6 +84,11 @@ case $1 in
     docker push crystallang/crystal:$2-build
     docker push crystallang/crystal:$2-i386
     docker push crystallang/crystal:$2-i386-build
+
+    readme=$(mktemp)
+    curl -sL https://github.com/crystal-lang/crystal/raw/$2/README.md > $readme
+    docker pushrm crystallang/crystal -f $readme
+    rm $readme
     ;;
 
   # Upload docs in .tar.gz file to https://crystal-lang.org/api/{version}


### PR DESCRIPTION
Using https://github.com/christian-korneck/docker-pushrm

Alternatives I found all require setting `DOCKER_USER` and `DOCKER_PASSWORD` or alike,
this seems like the only one that can parse the stored credentials from `docker login`.

YMMV, consider this a "please find a way to keep the readme updated" :) In other words,
no I didn't test this :D 
